### PR TITLE
removing liquid-pump from prototypes

### DIFF
--- a/prototypes/pump-1.lua
+++ b/prototypes/pump-1.lua
@@ -5,7 +5,7 @@ data:extend({
     name = "AOP-pumpjack-1",
     icon = "__base__/graphics/icons/pumpjack.png",
     flags = {"goes-to-quickbar"},
-    subgroup = "liquid-pump",
+    subgroup = "extraction-machine",
     place_result = "AOP-pumpjack-1",
     stack_size = 20
   },

--- a/prototypes/pump-2.lua
+++ b/prototypes/pump-2.lua
@@ -5,7 +5,7 @@ data:extend({
     name = "AOP-pumpjack-2",
     icon = "__base__/graphics/icons/pumpjack.png",
     flags = {"goes-to-quickbar"},
-    subgroup = "liquid-pump",
+    subgroup = "extraction-machine",
     place_result = "AOP-pumpjack-2",
     stack_size = 20
   },

--- a/prototypes/pump-3.lua
+++ b/prototypes/pump-3.lua
@@ -5,7 +5,7 @@ data:extend({
     name = "AOP-pumpjack-3",
     icon = "__base__/graphics/icons/pumpjack.png",
     flags = {"goes-to-quickbar"},
-    subgroup = "liquid-pump",
+    subgroup = "extraction-machine",
     order = "c",
     place_result = "AOP-pumpjack-3",
     stack_size = 20


### PR DESCRIPTION
changed subgroups to extraction-machine because liquid-pump dose not exist
